### PR TITLE
Fix: Castling verify KingMove not attacked

### DIFF
--- a/src/main/java/jchess/common/moveset/special/Castling.java
+++ b/src/main/java/jchess/common/moveset/special/Castling.java
@@ -41,7 +41,7 @@ public class Castling implements ISpecialRule {
             IChessGame game, PieceIdentifier kingId, PieceType rookTypeId, int kingToRookDir, int numStepsKing
     ) {
         this.game = game;
-        this.kingMove = repeat(filter(neighbor(kingToRookDir), Castling::kingStepFilter), numStepsKing, numStepsKing, true).toV1(kingId);
+        this.kingMove = repeat(filter(neighbor(kingToRookDir), this::kingStepFilter), numStepsKing, numStepsKing, true).toV1(kingId);
         this.kingId = kingId;
         this.rookTypeId = rookTypeId;
         this.kingToRookDir = kingToRookDir;
@@ -57,11 +57,11 @@ public class Castling implements ISpecialRule {
         game.getEventManager().getEvent(PieceMoveEvent.class).addListener(this::onPieceMove);
     }
 
-    private static boolean kingStepFilter(Entity moveTo) {
+    private boolean kingStepFilter(Entity moveTo) {
         // Castling requires that:
         // - the tiles the king moves over are empty
         // - the tiles the king moves over are not attacked
-        return moveTo.piece == null && !moveTo.isAttacked();
+        return moveTo.piece == null && !moveTo.isAttacked(kingId.ownerId());
     }
 
     private void lookupRook() {

--- a/src/main/java/jchess/ecs/Entity.java
+++ b/src/main/java/jchess/ecs/Entity.java
@@ -25,11 +25,13 @@ public class Entity {
 
     public boolean isAttacked() {
         if (tile == null || piece == null) return false;
+        return isAttacked(piece.identifier.ownerId());
+    }
 
-        final int ownerId = piece.identifier.ownerId();
-        return tile.attackingPieces.stream().anyMatch(attacker -> {
+    public boolean isAttacked(int attackedPlayer) {
+        return tile != null && tile.attackingPieces.stream().anyMatch(attacker -> {
             assert attacker.piece != null; // attacker must be a piece.
-            return attacker.piece.identifier.ownerId() != ownerId;
+            return attacker.piece.identifier.ownerId() != attackedPlayer;
         });
     }
 }


### PR DESCRIPTION
Der Fehler war in `Entity#isAttacked`, denn wenn kein Piece auf dem Feld steht, konnte `isAttacked` nicht ermittelt werden.

Lösung: Neue Methode, die ownerId annimmt.